### PR TITLE
Fix for problem with log level being forced to debug

### DIFF
--- a/include/iec104_utility.h
+++ b/include/iec104_utility.h
@@ -29,8 +29,8 @@ namespace Iec104Utility {
         #ifdef UNIT_TEST
         printf(std::string(format).append("\n").c_str(), std::forward<Args>(args)...);
         fflush(stdout);
-        #endif
         Logger::getLogger()->debug(format.c_str(), std::forward<Args>(args)...);
+        #endif
     }
 
     template<class... Args>

--- a/src/iec104.cpp
+++ b/src/iec104.cpp
@@ -50,6 +50,7 @@ void IEC104::start()
     std::string beforeLog = Iec104Utility::PluginName + " - IEC104::start -";
     Iec104Utility::log_info("%s Starting iec104", beforeLog.c_str());
 
+/* NOT NEEDED, LET SOUTH SERVICE MANAGE MIN LOG LEVEL
     switch (m_config->LogLevel())
     {
         case 1:
@@ -67,6 +68,7 @@ void IEC104::start()
             break;
         //LCOV_EXCL_STOP    
     }
+    */
 
     m_client = new IEC104Client(this, m_config);
 


### PR DESCRIPTION
- Removed minimum log lovel setup in start() function
- Debug log level only on unit test mode