### PR TITLE
PMP2-321 Removed code used to send "cnx_loss_status_id" type messages

### DIFF
--- a/include/iec104_client.h
+++ b/include/iec104_client.h
@@ -75,8 +75,6 @@ public:
 
     void updateGiStatus(GiStatus newState);
 
-    bool sendCnxLossStatus(bool value);
-
     GiStatus getGiStatus();
 
     static bool isMessageTypeMatching(int expectedType, int rcvdType);
@@ -94,8 +92,6 @@ private:
     std::vector<std::shared_ptr<DataExchangeDefinition>> m_listOfStationGroupDatapoints;
 
     std::shared_ptr<IEC104ClientConfig> m_config;
-
-    Datapoint* m_createCnxLossStatus(std::shared_ptr<DataExchangeDefinition> dp, bool value, uint64_t timestamp);
 
     class OutstandingCommand {
     public:

--- a/include/iec104_client_config.h
+++ b/include/iec104_client_config.h
@@ -68,8 +68,6 @@ public:
 
     std::string& GetConnxStatusSignal() {return m_connxStatus;};
 
-    std::string& GetCnxLossStatusId() {return m_cnxLossStatusId;};
-
     std::string& GetPrivateKey() {return m_privateKey;};
     std::string& GetOwnCertificate() {return m_ownCertificate;};
     std::vector<std::string>& GetRemoteCertificates() {return m_remoteCertificates;};
@@ -96,8 +94,6 @@ public:
     std::string* checkExchangeDataLayer(int typeId, int ca, int ioa);
 
     std::shared_ptr<DataExchangeDefinition> getExchangeDefinitionByLabel(std::string& label);
-
-    std::shared_ptr<DataExchangeDefinition> getCnxLossStatusDatapoint();
 
     int GetMaxRedGroups() const {return m_max_red_groups;};
 
@@ -144,9 +140,6 @@ private:
     bool m_tlsConfigComplete = false; /* flag if tls configuration is read */
 
     std::string m_connxStatus = ""; /* "asset" name for south plugin monitoring event */
-
-    bool m_sendCnxLossStatus = false; /* send info when GI is complete after connection loss */
-    std::string m_cnxLossStatusId = ""; /* assed ID of the connection loss indication data point */
 
     std::string m_privateKey = "";
     std::string m_ownCertificate = "";

--- a/include/iec104_client_connection.h
+++ b/include/iec104_client_connection.h
@@ -97,7 +97,6 @@ private:
     bool m_startDtSent = false;
 
     bool m_giRequested = false; /* Ask for a request GI to be sent. Triggered by the receptions of messages flagges gi". */
-
     bool m_cnxLostStatusSent = false; /* cnxLostStatus sent after reconnect */
 
     bool m_timeSynchronized = false;

--- a/src/iec104_client.cpp
+++ b/src/iec104_client.cpp
@@ -205,25 +205,14 @@ void IEC104Client::updateQualityForAllDataObjects(QualityDescriptor qd)
             if (dp) {
                 if (isDataPointInMonitoringDirection(dp))
                 {
-                    bool skipDatapoint = false;
+                    //TODO also add timestamp?
 
-                    if (m_config->GetCnxLossStatusId().empty() == false) {
-                        if (dp->label == m_config->GetCnxLossStatusId()) {
-                            skipDatapoint = true;
-                        }
+                    Datapoint* qualityUpdateDp = m_createQualityUpdateForDataObject(dp, &qd, nullptr);
+
+                    if (qualityUpdateDp) {
+                        datapoints.push_back(qualityUpdateDp);
+                        labels.push_back(dp->label);
                     }
-
-                    if (skipDatapoint == false) {
-                        //TODO also add timestamp?
-
-                        Datapoint* qualityUpdateDp = m_createQualityUpdateForDataObject(dp, &qd, nullptr);
-
-                        if (qualityUpdateDp) {
-                            datapoints.push_back(qualityUpdateDp);
-                            labels.push_back(dp->label);
-                        }
-                    }
-
                 }
             }
         }
@@ -358,52 +347,6 @@ Datapoint* IEC104Client::m_createDataObject(CS101_ASDU asdu, int64_t ioa, const 
 
          attributes->push_back(m_createDatapoint("do_ts_sub", (CP56Time2a_isSubstituted(ts)) ? 1L : 0L));
     }
-
-    DatapointValue dpv(attributes, true);
-
-    return new Datapoint("data_object", dpv);
-}
-
-Datapoint* IEC104Client::m_createCnxLossStatus(std::shared_ptr<DataExchangeDefinition> dp, bool value, uint64_t timestamp)
-{
-    auto* attributes = new vector<Datapoint*>;
-
-    attributes->push_back(m_createDatapoint("do_type", IEC104ClientConfig::getStringFromTypeID(dp->typeId)));
-
-    attributes->push_back(m_createDatapoint("do_ca", (long)dp->ca));
-
-    attributes->push_back(m_createDatapoint("do_oa", (long)0));
-
-    attributes->push_back(m_createDatapoint("do_cot", (long)3));
-
-    attributes->push_back(m_createDatapoint("do_test", (long)0));
-
-    attributes->push_back(m_createDatapoint("do_negative", (long)0));
-
-    attributes->push_back(m_createDatapoint("do_ioa", (long)dp->ioa));
-
-    if (value)
-        attributes->push_back(m_createDatapoint("do_value", 1L));
-    else
-        attributes->push_back(m_createDatapoint("do_value", 0L));
-
-    attributes->push_back(m_createDatapoint("do_quality_iv", 0L));
-
-    attributes->push_back(m_createDatapoint("do_quality_bl", 0L));
-
-    attributes->push_back(m_createDatapoint("do_quality_ov", 0L));
-
-    attributes->push_back(m_createDatapoint("do_quality_sb", 0L));
-
-    attributes->push_back(m_createDatapoint("do_quality_nt", 0L));
-
-    attributes->push_back(m_createDatapoint("do_ts", (long)timestamp));
-
-    attributes->push_back(m_createDatapoint("do_ts_iv", 0L));
-
-    attributes->push_back(m_createDatapoint("do_ts_su", 0L));
-
-    attributes->push_back(m_createDatapoint("do_ts_sub", 0L));
 
     DatapointValue dpv(attributes, true);
 
@@ -555,28 +498,6 @@ IEC104Client::updateGiStatus(GiStatus newState)
             Thread_sleep(200);
         }
     #endif
-}
-
-bool
-IEC104Client::sendCnxLossStatus(bool value)
-{
-    std::string beforeLog = Iec104Utility::PluginName + " - IEC104Client::sendCnxLossStatus -";
-    std::shared_ptr<DataExchangeDefinition> dp = m_config->getCnxLossStatusDatapoint();
-
-    if (dp) {
-        Iec104Utility::log_info("%s send cnx_loss_status (data point: %s)", beforeLog.c_str(), dp->label.c_str());
-
-        Datapoint* cnxLossStatusDp = m_createCnxLossStatus(dp, value, Hal_getTimeInMs());
-
-        std::vector<Datapoint*> points;
-        points.push_back(cnxLossStatusDp);
-
-        m_iec104->ingest(dp->label, points);
-
-        return true;
-    }
-
-    return false;
 }
 
 IEC104Client::GiStatus

--- a/src/iec104_client_config.cpp
+++ b/src/iec104_client_config.cpp
@@ -451,23 +451,6 @@ void IEC104ClientConfig::importProtocolConfig(const string& protocolConfig)
             else {
                 Iec104Utility::log_error("%s south_monitoring is missing \"asset\" element", beforeLog.c_str());
             }
-
-            if (southMonitoring.HasMember("cnx_loss_status_id")) {
-                if (southMonitoring["cnx_loss_status_id"].IsString()) {
-
-                    m_cnxLossStatusId = southMonitoring["cnx_loss_status_id"].GetString();
-
-                    if (m_cnxLossStatusId.empty()) {
-                        m_sendCnxLossStatus = false;
-                    }
-                    else {
-                        m_sendCnxLossStatus = true;
-                    }
-                }
-                else {
-                    Iec104Utility::log_error("%s south_monitoring \"cnx_loss_status_id\" element is not a string", beforeLog.c_str());
-                }
-            }
         }
         else {
             Iec104Utility::log_error("%s south_monitoring is not an object", beforeLog.c_str());
@@ -1069,35 +1052,6 @@ IEC104ClientConfig::getExchangeDefinitionByLabel(std::string& label)
                 }
             }
         }
-    }
-
-    return nullptr;
-}
-
-std::shared_ptr<DataExchangeDefinition>
-IEC104ClientConfig::getCnxLossStatusDatapoint()
-{
-    std::string beforeLog = Iec104Utility::PluginName + " - IEC104ClientConfig::getCnxLossStatusDatapoint -";
-    if (m_sendCnxLossStatus) {
-        auto cnxLossStatusDp = getExchangeDefinitionByLabel(m_cnxLossStatusId);
-
-        if (cnxLossStatusDp != nullptr) {
-            if ((cnxLossStatusDp->typeId == M_SP_NA_1) || (cnxLossStatusDp->typeId == M_SP_TB_1)) {
-                return cnxLossStatusDp;
-            }
-
-            Iec104Utility::log_warn("%s Data point for cnx_loss_status_id is not a single point status: %s (%d)", beforeLog.c_str(),
-                                    IEC104ClientConfig::getStringFromTypeID(cnxLossStatusDp->typeId).c_str(), cnxLossStatusDp->typeId);
-        }
-        else {
-            Iec104Utility::log_warn("%s Data point for cnx_loss_status_id '%s' not found in exchange data", beforeLog.c_str(),
-                                    m_cnxLossStatusId.c_str());
-        }
-
-        m_sendCnxLossStatus = false;
-    }
-    else {
-        Iec104Utility::log_debug("%s Connection loss status message disabled", beforeLog.c_str());
     }
 
     return nullptr;

--- a/src/iec104_client_connection.cpp
+++ b/src/iec104_client_connection.cpp
@@ -95,8 +95,6 @@ IEC104ClientConnection::m_connectionHandler(void* parameter, CS104_Connection co
         self->m_connectionState = CON_STATE_CLOSED;
         self->m_connected = false;
         self->m_connecting = false;
-
-        self->m_client->sendCnxLossStatus(false);
     }
     else if (event == CS104_CONNECTION_OPENED)
     {
@@ -805,8 +803,6 @@ IEC104ClientConnection::m_asduReceivedHandler(void* parameter, int address,
 
                                 self->m_client->updateQualityForDataObjectsNotReceivedInGIResponse(IEC60870_QUALITY_INVALID);
 
-                                self->m_client->sendCnxLossStatus(true);
-                                self->m_client->sendCnxLossStatus(false); // transient single point reset
                                 Iec104Utility::log_debug("%s Received ACT_TERM", beforeLog.c_str());
                             }
                             else {

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -244,8 +244,7 @@ static string protocol_config_broken4 = QUOTE({
                 "time_sync" : 1
             },
             "south_monitoring" : {
-                "asset": "CONSTAT-1",
-                "cnx_loss_status_id" : ""
+                "asset": "CONSTAT-1"
             }
         }
     });

--- a/tests/test_legacy_conn_handling.cpp
+++ b/tests/test_legacy_conn_handling.cpp
@@ -578,9 +578,9 @@ TEST_F(LegacyConnectionHandlingTest, ConnectionLost)
 
     Thread_sleep(1000);
 
-    ASSERT_EQ(8, ingestCallbackCalled);
+    ASSERT_EQ(6, ingestCallbackCalled);
 
-    ASSERT_EQ(8, storedReadings.size());
+    ASSERT_EQ(6, storedReadings.size());
 
     vector<string> expected_unique_events;
 
@@ -596,22 +596,21 @@ TEST_F(LegacyConnectionHandlingTest, ConnectionLost)
 
     int i = 0;
 
+    // TM-1 41025-4202832
     ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[i]));
     ASSERT_FALSE(IsReadingWithQualityNonTopcial(storedReadings[i++]));
 
+    // TM-2 41025-4202852
     ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[i]));
     ASSERT_FALSE(IsReadingWithQualityNonTopcial(storedReadings[i++]));
 
+    // TS-1 41025-4206948
     ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[i]));
     ASSERT_FALSE(IsReadingWithQualityNonTopcial(storedReadings[i++]));
 
-    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[i]));
-    ASSERT_FALSE(IsReadingWithQualityNonTopcial(storedReadings[i++]));
-
-    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[i++]));
-    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[i++]));
-    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[i++]));
-    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[i++]));
+    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[i++])); // TM-1 41025-4202832
+    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[i++])); // TM-2 41025-4202852
+    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[i++])); // TS-1 41025-4206948
 }
 
 TEST_F(LegacyConnectionHandlingTest, ConnectionLostReconnect)
@@ -653,16 +652,14 @@ TEST_F(LegacyConnectionHandlingTest, ConnectionLostReconnect)
     expected_unique_events.push_back("{\"connx_status\":\"not connected\"}");
 
     ASSERT_TRUE(containSouthEventsInRightOrder(storedLegacyReadings,expected_unique_events));
-    
-    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[0]));
-    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[1]));
-    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[2]));
-    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[3]));
 
-    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[4]));
-    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[5]));
-    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[6]));
-    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[7]));
+    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[0])); // TM-1 41025-4202832
+    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[1])); // TM-2 41025-4202852
+    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[2])); // TS-1 41025-4206948
+
+    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[3])); // TM-1 41025-4202832
+    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[4])); // TM-2 41025-4202852
+    ASSERT_TRUE(IsReadingWithQualityNonTopcial(storedReadings[5])); // TS-1 41025-4206948
 }
 
 TEST_F(LegacyConnectionHandlingTest, SendConnectionStatusAfterRequestFromNorth)
@@ -677,9 +674,9 @@ TEST_F(LegacyConnectionHandlingTest, SendConnectionStatusAfterRequestFromNorth)
 
     bool operationResult = iec104->operation("request_connection_status", 0, nullptr);
 
-    ASSERT_EQ(4, ingestCallbackCalled);
+    ASSERT_EQ(3, ingestCallbackCalled);
 
-    ASSERT_EQ(4, storedReadings.size());
+    ASSERT_EQ(3, storedReadings.size());
 
     vector<string> expected_unique_events;
 
@@ -687,11 +684,9 @@ TEST_F(LegacyConnectionHandlingTest, SendConnectionStatusAfterRequestFromNorth)
 
     ASSERT_TRUE(containSouthEventsInRightOrder(storedLegacyReadings,expected_unique_events));
 
-    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[0]));
-    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[1]));
-    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[2]));
-    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[3]));
-
+    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[0])); // TM-1 41025-4202832
+    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[1])); // TM-2 41025-4202852
+    ASSERT_TRUE(IsReadingWithQualityInvalid(storedReadings[2])); // TS-1 41025-4206948
 }
 
 TEST_F(LegacyConnectionHandlingTest, ConnectionLostStatus)

--- a/tests/test_legacy_conn_handling.cpp
+++ b/tests/test_legacy_conn_handling.cpp
@@ -58,8 +58,7 @@ static string protocol_config = QUOTE({
                 "time_sync" : 1
             },
             "south_monitoring" : {
-                "asset": "CONSTAT-1",
-                "cnx_loss_status_id" : "CNXLOSS-1"
+                "asset": "CONSTAT-1"
             }
         }
     });
@@ -103,8 +102,7 @@ static string protocol_config_no_red = QUOTE({
                 "time_sync" : 1
             },
             "south_monitoring" : {
-                "asset": "CONSTAT-1",
-                "cnx_loss_status_id" : "CNXLOSS-1"
+                "asset": "CONSTAT-1"
             }
         }
     });
@@ -171,16 +169,6 @@ static string exchanged_data = QUOTE({
                           "name":"iec104",
                           "address":"41025-2002",
                           "typeid":"C_DC_NA_1"
-                       }
-                    ]
-                },
-                {
-                    "label":"TM-B-1",
-                    "protocols":[
-                       {
-                          "name":"iec104",
-                          "address":"41026-2001",
-                          "typeid":"M_ME_NA_1"
                        }
                     ]
                 }
@@ -250,16 +238,6 @@ static string exchanged_data_2 = QUOTE({
                           "name":"iec104",
                           "address":"41025-2002",
                           "typeid":"C_DC_NA_1"
-                       }
-                    ]
-                },
-                {
-                    "label":"CNXLOSS-1",
-                    "protocols":[
-                       {
-                          "name":"iec104",
-                          "address":"41026-2001",
-                          "typeid":"M_SP_NA_1"
                        }
                     ]
                 }
@@ -757,8 +735,8 @@ TEST_F(LegacyConnectionHandlingTest, ConnectionLostStatus)
 
     ASSERT_TRUE(containSouthEventsInRightOrder(storedLegacyReadings,expected_unique_events));
 
-    ASSERT_EQ(7, ingestCallbackCalled);
+    ASSERT_EQ(6, ingestCallbackCalled);
 
-    ASSERT_EQ(7, storedReadings.size());
+    ASSERT_EQ(6, storedReadings.size());
 
 }


### PR DESCRIPTION
The plugins [rule-systemsp](https://github.com/fledge-power/fledgepower-rule-systemsp) and [notify-systemsp](https://github.com/fledge-power/fledgepower-notify-systemsp) already provide the behavior of sending "cnx_loss_status_id" type messages.